### PR TITLE
combine every osc with its envelope using (mult)

### DIFF
--- a/sofkasim.py
+++ b/sofkasim.py
@@ -66,7 +66,13 @@ class Sofka:
         sources = [o for o in self.oscillators if o]
         sources += [e for e in self.envelopes if e]
         dprint('SOURCES', sources)
-        output = ' '.join(['(seq %s)' % ' '.join(s.out()) for s in sources])
+        oscs = sources[0].out()
+        envs = sources[1].out()
+        assert len(oscs) == len(envs)
+        output = ''
+        for i, osc in enumerate(oscs):
+            output += f'(mult {osc} {envs[i]}) '
+        return f'(seq {output})'
         return '(mult %s)' % output
 
     def secs(self, n):


### PR DESCRIPTION
Quick test to check the improvement over https://github.com/hornc/musysim/pull/6 by playing sound combined with its envelope to avoid them getting out of sync.

`(seq (mult (osc ...) (env ...)) (mult ...) ... )`

Yes, it works, no noticeable clicking!

Needs refactoring and some thought about whether this will cause problems with more complicated combinations of sounds and envelopes and channels. 

Relates to #1  

Replaces #6 

Need to consider how the multiple oscillators, multiple envelope generators, and other possible sound sources all work together in terms of sequencing. I did this quickly after not having touched this for months -- I may have overlooked something :) 


Test:
`./musysim.py examples/random-tone-rows2.musys; ./sofkasim.py | ny`
generated 3m35s tune, no obvious clicking. Note envelopes at the end of the piece as in sync as those at the start, as desired.
